### PR TITLE
Fix links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ The following exchange rate pairs are currently supported:
 
 Only 100% open and free providers are queried:
 
-- [Bittrex](bittrex.com)
-- [CoinCap](api.coincap.io)
-- [CoinGecko](api.coingecko.com)
+- [Bittrex](https://bittrex.com)
+- [CoinCap](https://coincap.io)
+- [CoinGecko](https://coingecko.com)
 
 ## Installation
 


### PR DESCRIPTION
Without the https part, the links in the README were
treated as links to internal files and not the websites
that they were meant to be.