### PR TITLE
Demote Bittrex as USDC rate provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-exchange-rate",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-exchange-rate",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Safely get exchange rates",
   "keywords": [
     "exchange",

--- a/src/index.js
+++ b/src/index.js
@@ -89,9 +89,9 @@ function getExchangeRate(pair) {
     case 'USDC:USD':
       return promiseFind(
         [
-          () => bittrex.getTickerValue('USD-USDC'),
           () => coincap.getAsset('usd-coin'),
-          () => coingecko.getCoinPrice('usd-coin')
+          () => coingecko.getCoinPrice('usd-coin'),
+          () => bittrex.getTickerValue('USD-USDC')
         ].map(ignoreFailure)
       )
     case 'WBTC:USD':


### PR DESCRIPTION
It seems to be not in line with other sources as it jumped from 1.00 to 1.05 while others did not.